### PR TITLE
feat: changable playpause button

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,9 @@
 
   [module/mrpis-play-pause]
   type = custom/script
-  exec = echo "懶"
+  exec = ~/.config/polybar/scripts/mpris/mpris_control.sh --playingstatus
   format = <label>
+  interval = 1
   click-left = ~/.config/polybar/scripts/mpris/mpris_control.sh --playpause
 
   [module/mrpis-next]

--- a/mpris/mpris_control.sh
+++ b/mpris/mpris_control.sh
@@ -51,6 +51,16 @@ update_state() {
     fi
 }
 
+query_playing_status() {
+    CUR_PLAYER=$(cat ~/.config/polybar/.curplayer.log)
+    status=$(playerctl --player=$CUR_PLAYER status 2>/dev/null)
+    if [ "$status" == "Playing" ]; then
+        echo ""
+    else
+        echo ""
+    fi
+}
+
 get_title() {
     cmd="playerctl --player=${CUR_PLAYER} metadata --format $FORMAT 2>/dev/null"
     eval $cmd
@@ -152,4 +162,6 @@ elif [ "$1" == "--previous" ]; then
     to_previous
 elif [ "$1" == "--vc" ]; then
     to_volume $2
+elif [ "$1" == "--playingstatus" ]; then
+    query_playing_status   
 fi


### PR DESCRIPTION
Added a feature that the label of `mrpis-play-pause` can change according to the real-time playing status(i.e. whether it is playing or not). 

**P.S.** The font I use is Nerd Font, which may not be compatible with the original fonts.

---
给播放/暂停键增加了可以随实际播放状态变化的功能。

**又及：** 用的是 Nerd Font，和原本的可能不兼容（？）